### PR TITLE
hotfix: change stub paths to fit our package path inside vendor

### DIFF
--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -41,15 +41,15 @@ class PublishCommand extends Command
             $composePath,
             str_replace(
                 [
-                    './vendor/laravel/sail/runtimes/8.5',
-                    './vendor/laravel/sail/runtimes/8.4',
-                    './vendor/laravel/sail/runtimes/8.3',
-                    './vendor/laravel/sail/runtimes/8.2',
-                    './vendor/laravel/sail/runtimes/8.1',
-                    './vendor/laravel/sail/runtimes/8.0',
-                    './vendor/laravel/sail/database/mariadb',
-                    './vendor/laravel/sail/database/mysql',
-                    './vendor/laravel/sail/database/pgsql'
+                    './vendor/startap/sail-podman/runtimes/8.5',
+                    './vendor/startap/sail-podman/runtimes/8.4',
+                    './vendor/startap/sail-podman/runtimes/8.3',
+                    './vendor/startap/sail-podman/runtimes/8.2',
+                    './vendor/startap/sail-podman/runtimes/8.1',
+                    './vendor/startap/sail-podman/runtimes/8.0',
+                    './vendor/startap/sail-podman/database/mariadb',
+                    './vendor/startap/sail-podman/database/mysql',
+                    './vendor/startap/sail-podman/database/pgsql'
                 ],
                 [
                     './docker/8.5',

--- a/stubs/compose.stub
+++ b/stubs/compose.stub
@@ -2,7 +2,7 @@
 services:
     laravel.test:
         build:
-            context: ./vendor/laravel/sail/runtimes/{{PHP_VERSION}}
+            context: ./vendor/startap/sail-podman/runtimes/{{PHP_VERSION}}
             dockerfile: Dockerfile
             args:
                 WWWGROUP: '${WWWGROUP}'

--- a/stubs/mariadb.stub
+++ b/stubs/mariadb.stub
@@ -11,7 +11,7 @@ mariadb:
         MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
     volumes:
         - 'sail-mariadb:/var/lib/mysql'
-        - './vendor/laravel/sail/database/mariadb/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
+        - './vendor/startap/sail-podman/database/mariadb/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
     networks:
         - sail
     healthcheck:

--- a/stubs/mysql.stub
+++ b/stubs/mysql.stub
@@ -12,7 +12,7 @@ mysql:
         MYSQL_EXTRA_OPTIONS: '${MYSQL_EXTRA_OPTIONS:-}'
     volumes:
         - 'sail-mysql:/var/lib/mysql'
-        - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
+        - './vendor/startap/sail-podman/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
     networks:
         - sail
     healthcheck:

--- a/stubs/pgsql.stub
+++ b/stubs/pgsql.stub
@@ -9,7 +9,7 @@ pgsql:
         POSTGRES_PASSWORD: '${DB_PASSWORD:-secret}'
     volumes:
         - 'sail-pgsql:/var/lib/postgresql'
-        - './vendor/laravel/sail/database/pgsql/create-testing-database.sql:/docker-entrypoint-initdb.d/10-create-testing-database.sql'
+        - './vendor/startap/sail-podman/database/pgsql/create-testing-database.sql:/docker-entrypoint-initdb.d/10-create-testing-database.sql'
     networks:
         - sail
     healthcheck:


### PR DESCRIPTION
Replace our stubs paths from `laravel/sail` to `startap/sail-podman`. This fix the `artisan:publish` process and the `composer.yaml` generated file.